### PR TITLE
Add translations for "LUCK" and for move-effects inside of the pokemon information screen ("PP", "POWER", "CATEGORY", ...)

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -52,7 +52,7 @@ import { UiTheme } from "./enums/ui-theme";
 import { SceneBase } from "./scene-base";
 import CandyBar from "./ui/candy-bar";
 import { Variant, variantData } from "./data/variant";
-import { Localizable } from "./plugins/i18n";
+import i18next, { Localizable } from "./plugins/i18n";
 import * as Overrides from "./overrides";
 import {InputsController} from "./inputs-controller";
 import {UiInputs} from "./ui-inputs";
@@ -369,7 +369,7 @@ export default class BattleScene extends SceneBase {
     this.luckText.setVisible(false);
     this.fieldUI.add(this.luckText);
 
-    this.luckLabelText = addTextObject(this, (this.game.canvas.width / 6) - 2, 0, "Luck:", TextStyle.PARTY, { fontSize: "54px" });
+    this.luckLabelText = addTextObject(this, (this.game.canvas.width / 6) - 2, 0, `${i18next.t("pokemonInfo:Stat.LUCK")}:`, TextStyle.PARTY, { fontSize: "54px" });
     this.luckLabelText.setOrigin(1, 0);
     this.luckLabelText.setVisible(false);
     this.fieldUI.add(this.luckLabelText);

--- a/src/locales/de/config.ts
+++ b/src/locales/de/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const deConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/de/fight-ui-handler.ts
+++ b/src/locales/de/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "AP",
-  "power": "Stärke",
-  "accuracy": "Genauigkeit",
-} as const;

--- a/src/locales/de/pokemon-info.ts
+++ b/src/locales/de/pokemon-info.ts
@@ -14,6 +14,7 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "SPDEFshortened": "SpVert",
     "SPD": "Initiative",
     "SPDshortened": "Init",
+    "LUCK": "Glück"
   },
 
   Type: {
@@ -38,4 +39,14 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fee",
     "STELLAR": "Stellar",
   },
+
+  Move: {
+    "MOVES": "ATTACKEN",
+    "DESCRIPTION": "BESCHREIBUNG",
+    "EFFECT_POWER": "Stärke",
+    "EFFECT": "EFFEKT",
+    "EFFECT_ACCURACY": "Genauigkeit",
+    "EFFECT_CATEGORY": "Kategorie",
+    "EFFECT_PP": "AP"
+  }
 } as const;

--- a/src/locales/en/config.ts
+++ b/src/locales/en/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const enConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/en/fight-ui-handler.ts
+++ b/src/locales/en/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Power",
-  "accuracy": "Accuracy",
-} as const;

--- a/src/locales/en/pokemon-info.ts
+++ b/src/locales/en/pokemon-info.ts
@@ -13,7 +13,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "SPDEF": "Sp. Def",
     "SPDEFshortened": "SpDef",
     "SPD": "Speed",
-    "SPDshortened": "Spd"
+    "SPDshortened": "Spd",
+    "LUCK": "Luck"
   },
 
   Type: {
@@ -38,4 +39,13 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fairy",
     "STELLAR": "Stellar",
   },
+  Move: {
+    "MOVES": "MOVES",
+    "DESCRIPTION": "DESCRIPTION",
+    "EFFECT": "EFFECT",
+    "EFFECT_POWER": "Power",
+    "EFFECT_ACCURACY": "Accuracy",
+    "EFFECT_CATEGORY": "Category",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/es/config.ts
+++ b/src/locales/es/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const esConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/es/fight-ui-handler.ts
+++ b/src/locales/es/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Potencia",
-  "accuracy": "Precisión",
-} as const;

--- a/src/locales/es/pokemon-info.ts
+++ b/src/locales/es/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Hada",
     "STELLAR": "Astral",
   },
+  Move: {
+    "EFFECT_POWER": "Potencia",
+    "EFFECT_ACCURACY": "Precisión",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/fr/config.ts
+++ b/src/locales/fr/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const frConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/fr/fight-ui-handler.ts
+++ b/src/locales/fr/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Puissance",
-  "accuracy": "Précision",
-} as const;

--- a/src/locales/fr/pokemon-info.ts
+++ b/src/locales/fr/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fée",
     "STELLAR": "Stellaire",
   },
+
+  Move: {
+    "EFFECT_POWER": "Puissance",
+    "EFFECT_ACCURACY": "Précision",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/it/config.ts
+++ b/src/locales/it/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const itConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/it/fight-ui-handler.ts
+++ b/src/locales/it/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Potenza",
-  "accuracy": "Precisione",
-} as const;

--- a/src/locales/it/pokemon-info.ts
+++ b/src/locales/it/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Folletto",
     "STELLAR": "Astrale",
   },
+
+  Move: {
+    "EFFECT_POWER": "Potenza",
+    "EFFECT_ACCURACY": "Precisione",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/pt_BR/config.ts
+++ b/src/locales/pt_BR/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const ptBrConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   menuUiHandler: menuUiHandler,
   menu: menu,
   move: move,

--- a/src/locales/pt_BR/fight-ui-handler.ts
+++ b/src/locales/pt_BR/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Poder",
-  "accuracy": "Precisão",
-} as const;

--- a/src/locales/pt_BR/pokemon-info.ts
+++ b/src/locales/pt_BR/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fada",
     "STELLAR": "Estelar"
   },
+
+  Move: {
+    "EFFECT_POWER": "Poder",
+    "EFFECT_ACCURACY": "Precisão",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/zh_CN/config.ts
+++ b/src/locales/zh_CN/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -29,7 +28,6 @@ export const zhCnConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/zh_CN/fight-ui-handler.ts
+++ b/src/locales/zh_CN/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "威力",
-  "accuracy": "命中",
-} as const;

--- a/src/locales/zh_CN/pokemon-info.ts
+++ b/src/locales/zh_CN/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "妖精",
     "STELLAR": "星晶",
   },
+
+  Move: {
+    "EFFECT_POWER": "威力",
+    "EFFECT_ACCURACY": "命中",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/zh_TW/config.ts
+++ b/src/locales/zh_TW/config.ts
@@ -3,7 +3,6 @@ import { abilityTriggers } from "./ability-trigger";
 import { battle } from "./battle";
 import { commandUiHandler } from "./command-ui-handler";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
@@ -28,7 +27,6 @@ export const zhTWConfig = {
   battle: battle,
   commandUiHandler: commandUiHandler,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,

--- a/src/locales/zh_TW/fight-ui-handler.ts
+++ b/src/locales/zh_TW/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "威力",
-  "accuracy": "命中率",
-} as const;

--- a/src/locales/zh_TW/pokemon-info.ts
+++ b/src/locales/zh_TW/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "妖精",
     "STELLAR": "星晶"
   },
+  Move: {
+    "EFFECT_POWER": "威力",
+    "EFFECT_ACCURACY": "命中率",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -49,6 +49,7 @@ export interface ModifierTypeTranslationEntries {
 export interface PokemonInfoTranslationEntries {
   Stat: SimpleTranslationEntries,
   Type: SimpleTranslationEntries,
+  Move: SimpleTranslationEntries
 }
 
 export interface BerryTranslationEntry {
@@ -146,7 +147,6 @@ declare module "i18next" {
       pokemon: SimpleTranslationEntries;
       pokemonInfo: PokemonInfoTranslationEntries;
       commandUiHandler: SimpleTranslationEntries;
-      fightUiHandler: SimpleTranslationEntries;
       titles: SimpleTranslationEntries;
       trainerClasses: SimpleTranslationEntries;
       trainerNames: SimpleTranslationEntries;

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -46,7 +46,7 @@ export default class FightUiHandler extends UiHandler {
     this.ppLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -26, "PP", TextStyle.MOVE_INFO_CONTENT);
     this.ppLabel.setOrigin(0.0, 0.5);
     this.ppLabel.setVisible(false);
-    this.ppLabel.setText(i18next.t("fightUiHandler:pp"));
+    this.ppLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_PP"));
     ui.add(this.ppLabel);
 
     this.ppText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -26, "--/--", TextStyle.MOVE_INFO_CONTENT);
@@ -57,7 +57,7 @@ export default class FightUiHandler extends UiHandler {
     this.powerLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -18, "POWER", TextStyle.MOVE_INFO_CONTENT);
     this.powerLabel.setOrigin(0.0, 0.5);
     this.powerLabel.setVisible(false);
-    this.powerLabel.setText(i18next.t("fightUiHandler:power"));
+    this.powerLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_POWER"));
     ui.add(this.powerLabel);
 
     this.powerText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -18, "---", TextStyle.MOVE_INFO_CONTENT);
@@ -68,7 +68,7 @@ export default class FightUiHandler extends UiHandler {
     this.accuracyLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -10, "ACC", TextStyle.MOVE_INFO_CONTENT);
     this.accuracyLabel.setOrigin(0.0, 0.5);
     this.accuracyLabel.setVisible(false);
-    this.accuracyLabel.setText(i18next.t("fightUiHandler:accuracy"));
+    this.accuracyLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_ACCURACY"));
     ui.add(this.accuracyLabel);
 
     this.accuracyText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -10, "---", TextStyle.MOVE_INFO_CONTENT);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -477,8 +477,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.type2Icon.setScale(0.5);
     this.type2Icon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.type2Icon);
-
-    this.pokemonLuckLabelText = addTextObject(this.scene, 8, 89, "Luck:", TextStyle.WINDOW_ALT, { fontSize: "56px" });
+    // TODOSVEN: translate
+    this.pokemonLuckLabelText = addTextObject(this.scene, 8, 89, `${i18next.t("pokemonInfo:Stat.LUCK")}:`, TextStyle.WINDOW_ALT, { fontSize: "56px" });
     this.pokemonLuckLabelText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonLuckLabelText);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -21,6 +21,7 @@ import { PlayerGender } from "../system/game-data";
 import { Variant, getVariantTint } from "#app/data/variant";
 import {Button} from "../enums/buttons";
 import { Ability } from "../data/ability.js";
+import i18next from "i18next";
 
 enum Page {
   PROFILE,
@@ -224,7 +225,7 @@ export default class SummaryUiHandler extends UiHandler {
     moveEffectBg.setOrigin(0, 0);
     this.moveEffectContainer.add(moveEffectBg);
 
-    const moveEffectLabels = addTextObject(this.scene, 8, 12, "Power\nAccuracy\nCategory", TextStyle.SUMMARY);
+    const moveEffectLabels = addTextObject(this.scene, 8, 12, `${i18next.t("pokemonInfo:Move.EFFECT_POWER")}\n${i18next.t("pokemonInfo:Move.EFFECT_ACCURACY")}\n${i18next.t("pokemonInfo:Move.EFFECT_CATEGORY")}`, TextStyle.SUMMARY);
     moveEffectLabels.setLineSpacing(9);
     moveEffectLabels.setOrigin(0, 0);
 
@@ -715,7 +716,7 @@ export default class SummaryUiHandler extends UiHandler {
       }
 
       if (this.pokemon.getLuck()) {
-        const luckLabelText = addTextObject(this.scene, 141, 28, "Luck:", TextStyle.SUMMARY_ALT);
+        const luckLabelText = addTextObject(this.scene, 141, 28, `${i18next.t("pokemonInfo:Stat.LUCK")}:`, TextStyle.SUMMARY_ALT);
         luckLabelText.setOrigin(0, 0);
         profileContainer.add(luckLabelText);
 


### PR DESCRIPTION
This PR aims to extend the localization features of pokerouge.
I've merged the translations from fight_ui_handler.ts into pokemon_information.ts and added other translations like category and luck.

I've also started adding translations for the header texts of the pokemon information screen (Effect, Description), which currently are still static images.

In an upcoming PR I'd like to make the images blank and render them via textObjects, as it should be.

![grafik](https://github.com/Admiral-Billy/pokerogue/assets/58704291/56f51b9b-a138-4bc6-8859-8cf76c268169)
![grafik](https://github.com/Admiral-Billy/pokerogue/assets/58704291/9fb1c49d-be81-41ce-8ac1-40d08ba55800)
![grafik](https://github.com/Admiral-Billy/pokerogue/assets/58704291/be467b47-8572-4d54-938d-1150b21236b0)
![grafik](https://github.com/Admiral-Billy/pokerogue/assets/58704291/0cd58d54-56ef-4ab0-9238-aee9226d5ed5)
