### PR TITLE
[QoL] Simplify version tracking

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -64,6 +64,7 @@ jobs:
       if: steps.check_match.outputs.stop_build != 'true'
       run: |
         cd dist
+        echo ${{ steps.latest_commit.outputs.latest_commit }} > currentVersion.txt
         zip -r game.zip .
 
     - name: Create Release


### PR DESCRIPTION
## What are the changes the user will see?
- None

## Why am I making these changes?
- So that offline apps no longer need to track what version they downloaded and write a version file. Put it into the release asset zip.

## What are the changes from a developer perspective?
- The offline clients can be updated to simplify versioning logic.
- In the future this can be updated again so that we do similar things for beta/mod builds so that the clients can display them as well